### PR TITLE
Fix the tiny typo in README.MD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ scripts inside `tools/fastlane` folder. To understand more about what can be don
 | Rule                                                                      | Explanation                                                                                                                                                                                                      |
 |---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Use trailing commas for method/constructor parameters and definitions** | This way each param is in a separate line and adding new params is much easier to read in PRs                                                                                                                    |
-| **Prefer named parameters**                                               | Whenever using more than one param, consider using named parameters, i.e: <font color="Red">Bad:</font>`getBalances(true,"1283184")`, <font color="Green">Bad:</font>`getBalances(id: "1283184", refresh: true)` |
+| **Prefer named parameters**                                               | Whenever using more than one param, consider using named parameters, i.e: <font color="Red">Bad:</font>`getBalances(true,"1283184")`, <font color="Green">Good:</font>`getBalances(id: "1283184", refresh: true)` |
 
 ### UseCase
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ scripts inside `tools/fastlane` folder. To understand more about what can be don
 | Rule                                                                      | Explanation                                                                                                                                                                                                      |
 |---------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Use trailing commas for method/constructor parameters and definitions** | This way each param is in a separate line and adding new params is much easier to read in PRs                                                                                                                    |
-| **Prefer named parameters**                                               | Whenever using more than one param, consider using named parameters, i.e: <font color="Red">Bad:</font>`getBalances(true,"1283184")`, <font color="Green">Good:</font>`getBalances(id: "1283184", refresh: true)` |
+| **Prefer named parameters**                                               | Whenever using more than one param, consider using named parameters, i.e: <font color="Red">Bad:</font> `getBalances(true, "1283184")`, <font color="Green">Good:</font> `getBalances(id: "1283184", refresh: true)` |
 
 ### UseCase
 


### PR DESCRIPTION
Changes the 
```
Bad:getBalances(true,"1283184"),
Bad:getBalances(id: "1283184", refresh: true)
```
to 
```
Bad: getBalances(true, "1283184"),
Good: getBalances(id: "1283184", refresh: true)
```
